### PR TITLE
Update azure-stack-acs-differences.md

### DIFF
--- a/azure-stack/user/azure-stack-acs-differences.md
+++ b/azure-stack/user/azure-stack-acs-differences.md
@@ -32,6 +32,7 @@ This article summarizes the known Azure Stack Hub Storage differences from Azure
 |Managed disks|Premium and standard supported|Supported when you use version 1808 or later.
 |Managed disk snapshots|General available|Supported.
 |Managed disk incremental snapshots|General available|Not yet supported.
+|Managed disk snapshots for VM in a running state|General available|Not yet supported.
 |Blob name|1,024 characters (2,048 bytes)|880 characters (1,760 bytes)
 |Block blob max size|4.75 TB (100 MB X 50,000 blocks)|4.75 TB (100 MB x 50,000 blocks) for the 1802 update or newer version. 50,000 X 4 MB (approximately 195 GB) for previous versions.
 |Page blob snapshot copy|Backup Azure unmanaged VM disks attached to a running VM supported|Supported in [API as an async operation](azure-stack-acs-differences.md).


### PR DESCRIPTION
I believe that [this commit](https://github.com/MicrosoftDocs/azure-stack-docs/commit/7dba98c688b7cde394ceb5fe1ffdd632960a8f8a#diff-0c77c8d280f29be8134fe7a63688394f) confuses users. This document needs more clarification about a running state.

https://github.com/MicrosoftDocs/azure-stack-docs/blob/master/azure-stack/user/azure-stack-manage-vm-protect.md#backup-using-disk-snapshot-snapshot-for-running-vms

> Using disk snapshots is currently not supported for VM in a running state

Best regards.